### PR TITLE
Improve Terminal Output

### DIFF
--- a/PhraseMaker.py
+++ b/PhraseMaker.py
@@ -1,5 +1,8 @@
-import random, math, string
+import random, math, string, sys
 from operator import itemgetter
+
+# Used so that sysout is not cleared on the first generation
+firstGen = True
 
 # Size of the population.
 # Not related to the length of the target string.
@@ -94,15 +97,21 @@ def getPair(valpop):
 
 # Load and return the next generation of 'creatures'.
 def nextGen(pop):
+    global firstGen
     valuedPop = [] # TODO: make the previous gen's valuedPop persist so we only have to evaluate half.
     population = pop
     for word in population:
         fitness = evaluate(word, finalPhrase) # Evaluate the fitness of the word.
         valuedPop.append((fitness, word)) # Add the fitness and word to the list.
     valuedPop.sort(key=itemgetter(0), reverse=True) # Sort best to worst.
+    if firstGen == False:
+        for i in range(0,3):
+            sys.stdout.write("\033[F")
+            sys.stdout.write("\033[K")
     print("Best: " + str(valuedPop[0][1]))
     print("Best fitness: " + str(valuedPop[0][0]))
     print("Generation: " + str(genNum + 1))
+    firstGen = False
     del(population)
     population = []
     for i in valuedPop:

--- a/PhraseMaker.py
+++ b/PhraseMaker.py
@@ -144,6 +144,9 @@ try:
     finalPhrase = str(raw_input("Phrase to search for: ")) # Target phrase from user input.
 except:
     finalPhrase = str(input("Phrase to search for: ")) # Needed for Python 3 compatibility.
+if len(finalPhrase) < 7:
+    print("Unable to run with phrases less than seven characters in length.")
+    exit()
 phraseLen = len(finalPhrase) # Set the length of the target.
 population = populate(popSize) # Make the first generation.
 fin = False


### PR DESCRIPTION
This works on Mac, not sure about Windows so needs testing before merging. Essentially, it deletes the previous output before adding the new one (creates a sort of typewriter effect).

I also prevented users from entering strings of less than seven characters in length as these cause an error in the mating algorithm.
